### PR TITLE
Fix AI discard causing card loss

### DIFF
--- a/rummy-logic.js
+++ b/rummy-logic.js
@@ -352,14 +352,14 @@ export class RummyGameLogic {
         let bestCardToDiscard = null;
         let discardPool = player.hand;
         if (discardPool.length === 0) {
-             if (player.melds.length > 0) {
+            if (player.melds.length > 0) {
                 player.melds.sort((a,b) => a.reduce((s,c)=>s+c.getPoints(),0) - b.reduce((s,c)=>s+c.getPoints(),0));
                 const meldToBreak = player.melds.shift();
                 discardPool = meldToBreak;
-             } else {
-                 player.lastDiscardedCard = drawnCard;
-                 return { drawn: drawnCard, discarded: drawnCard, declared: false };
-             }
+            } else {
+                player.lastDiscardedCard = drawnCard;
+                return { drawn: drawnCard, discarded: drawnCard, declared: false };
+            }
         }
         
         let lowestFutureScore = Infinity;
@@ -381,6 +381,10 @@ export class RummyGameLogic {
         const discardIndex = finalDiscardPool.indexOf(bestCardToDiscard);
         if (discardIndex > -1) {
             finalDiscardPool.splice(discardIndex, 1);
+        }
+        if (player.hand.length === 0 && finalDiscardPool !== player.hand) {
+            // We broke a meld to discard, so the remaining cards become the new hand
+            player.hand = finalDiscardPool;
         }
         
         player.lastDiscardedCard = bestCardToDiscard;


### PR DESCRIPTION
## Summary
- prevent the AI from losing cards when it must break a meld to discard

## Testing
- `node -e "import('./rummy-logic.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6866d02d4fbc833389073c6e38361c23