### PR TITLE
Fix AI turn in fast mode

### DIFF
--- a/main-v2.js
+++ b/main-v2.js
@@ -513,7 +513,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
         animateCard(card, startPos, endPos, onComplete, showBack = false, speed = 0.15) {
             if (this.fastMode) {
-                if (onComplete) onComplete();
+                this.isAnimating = true;
+                const finalize = () => {
+                    this.isAnimating = false;
+                    if (this.nextAction) {
+                        const action = this.nextAction;
+                        this.nextAction = null;
+                        action();
+                    }
+                };
+
+                const result = onComplete ? onComplete() : null;
+                if (result && typeof result.then === 'function') {
+                    result.then(finalize);
+                } else {
+                    finalize();
+                }
                 return;
             }
             const animation = {


### PR DESCRIPTION
## Summary
- ensure callbacks run correctly when animations are skipped in fast mode

## Testing
- `node --check main-v2.js`


------
https://chatgpt.com/codex/tasks/task_e_68676dd662648333a1fa9c29f979a359