### PR TITLE
Add post-AI meld step

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -35,6 +35,18 @@ export function updateButtons(App) {
     const totalCardsInHand = humanPlayer.hand.length;
     const selectionSize = humanPlayer.selectedIndices.length;
 
+    if (App.pendingAiDeclaration) {
+        Elements.sortButton.disabled = App.isAnimating;
+        Elements.meldButton.disabled = selectionSize < 3 || App.isAnimating;
+        Elements.discardButton.disabled = true;
+        Elements.declareButton.disabled = App.isAnimating;
+        Elements.declareButton.textContent = 'Show';
+        Elements.revealJokerButton.disabled = true;
+        return;
+    }
+
+    Elements.declareButton.textContent = 'Declare';
+
     Elements.sortButton.disabled = App.isAnimating;
     Elements.meldButton.disabled = !(isMyTurn && game.turn_state === 'ACTION' && selectionSize >= 3);
     Elements.discardButton.disabled = !(isMyTurn && game.turn_state === 'ACTION' && (totalCardsInHand + humanPlayer.melds.flat().length) === 14 && selectionSize === 1);


### PR DESCRIPTION
## Summary
- allow players to organise melds when the AI declares
- show "Show" button for finishing after computer declaration
- keep normal declare button otherwise

## Testing
- `node --check main-v2.js`
- `node --check ui.js`
- `node --check rummy-logic.js`


------
https://chatgpt.com/codex/tasks/task_e_6871cd25156c833380612f961bdbeb1e